### PR TITLE
Show hide modals on sign up and sign in

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -13,6 +13,8 @@ const signUpSuccess = (ajaxResponse) => {
 
   // Clear modal body text in SIGN UP modal
   $('#sign-up').trigger('reset')
+  $('#mySignUpModal').modal('toggle')
+  $('#mySignInModal').modal('toggle')
 }
 
 const signUpFailure = (error) => {
@@ -26,7 +28,7 @@ const signUpFailure = (error) => {
 const signInSuccess = (ajaxResponse) => {
   store.cart = { products: [] }
   console.log('(auth/ui.js) signInSuccess ran!  Data is :', ajaxResponse)
-
+  $('#mySignInModal').modal('toggle')
   // Store user object
   store.user = ajaxResponse.user
   console.log('ui.js: signInSuccess - store is: ', store)
@@ -77,9 +79,10 @@ const changePasswordFailure = (error) => {
 
 const signOutSuccess = () => {
   console.log('(auth/ui.js) signOutSuccess ran!  Nothing was returned')
-
-  // OREO COOKIE!
-  console.log('store is: ', store)
+  // clear cart
+  store.cart = null
+  // re-render cart
+  $('#cartHandlebar').html(' ')
   // Clear user
   store.user = null
   console.log('store is: ', store)

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -10,7 +10,6 @@ const stripeEvents = require('./stripe/stripe.js')
 
 const orderUi = require('./orders/ui.js')
 
-
 $(() => {
   setAPIOrigin(location, config)
   // Upon page load, hides all views except views passed in array to showView
@@ -22,10 +21,8 @@ $(() => {
   authEvents.addHandlers()
   stripeEvents.onPageLoad()
 
-
   // Hide View Order History modal button until user signs in
   orderUi.hideViewOrderHistoryBtn()
-
 })
 
 // use require with a reference to bundle the file and use it in this file


### PR DESCRIPTION
After successful sign up the sign in modal displays. After successful
sign in the sign in modal goes away. After a successful sign out the
cart store is cleared and the cart is re-rendered.